### PR TITLE
chore: release v0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.2](https://github.com/oxc-project/sort-package-json/compare/v0.0.1...v0.0.2) - 2025-12-08
+
+### Other
+
+- Update README field count to 126
+- Use unstable sort for better performance
+- Move main field below type field
+- Add declare_field_order! macro to simplify field ordering
+- Add napi field after bundleDependencies
+- Refactor value transformation with helper functions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "sort-package-json"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "criterion2",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sort-package-json"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Boshen <boshenc@gmail.com>"]
 categories = []
 edition = "2021"


### PR DESCRIPTION



## 🤖 New release

* `sort-package-json`: 0.0.1 -> 0.0.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.2](https://github.com/oxc-project/sort-package-json/compare/v0.0.1...v0.0.2) - 2025-12-08

### Other

- Update README field count to 126
- Use unstable sort for better performance
- Move main field below type field
- Add declare_field_order! macro to simplify field ordering
- Add napi field after bundleDependencies
- Refactor value transformation with helper functions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).