### PR TITLE
chore: release v0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.4](https://github.com/oxc-project/sort-package-json/compare/v0.0.3...v0.0.4) - 2025-12-17
+
+### Fixed
+
+- Keep `exports` paths order ([#5](https://github.com/oxc-project/sort-package-json/pull/5))
+
+### Other
+
+- Add 12 commonly-used fields from npm ecosystem analysis ([#8](https://github.com/oxc-project/sort-package-json/pull/8))
+- Improve field grouping with clearer logical organization ([#7](https://github.com/oxc-project/sort-package-json/pull/7))
+
 ## [0.0.3](https://github.com/oxc-project/sort-package-json/compare/v0.0.2...v0.0.3) - 2025-12-10
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "sort-package-json"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "criterion2",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sort-package-json"
-version = "0.0.3"
+version = "0.0.4"
 authors = ["Boshen <boshenc@gmail.com>"]
 categories = []
 edition = "2021"


### PR DESCRIPTION



## 🤖 New release

* `sort-package-json`: 0.0.3 -> 0.0.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.4](https://github.com/oxc-project/sort-package-json/compare/v0.0.3...v0.0.4) - 2025-12-17

### Fixed

- Keep `exports` paths order ([#5](https://github.com/oxc-project/sort-package-json/pull/5))

### Other

- Add 12 commonly-used fields from npm ecosystem analysis ([#8](https://github.com/oxc-project/sort-package-json/pull/8))
- Improve field grouping with clearer logical organization ([#7](https://github.com/oxc-project/sort-package-json/pull/7))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).