### PR TITLE
chore: release v0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.5](https://github.com/oxc-project/sort-package-json/compare/v0.0.4...v0.0.5) - 2025-12-17
+
+### Other
+
+- Optimize more functions with in-place mutations
+- Optimize array sorting with in-place operations ([#14](https://github.com/oxc-project/sort-package-json/pull/14))
+- Use unstable sort for better performance ([#13](https://github.com/oxc-project/sort-package-json/pull/13))
+- Sort files field with natural path sorting ([#10](https://github.com/oxc-project/sort-package-json/pull/10))
+
 ## [0.0.4](https://github.com/oxc-project/sort-package-json/compare/v0.0.3...v0.0.4) - 2025-12-17
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "sort-package-json"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "criterion2",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sort-package-json"
-version = "0.0.4"
+version = "0.0.5"
 authors = ["Boshen <boshenc@gmail.com>"]
 categories = []
 edition = "2021"


### PR DESCRIPTION



## 🤖 New release

* `sort-package-json`: 0.0.4 -> 0.0.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.5](https://github.com/oxc-project/sort-package-json/compare/v0.0.4...v0.0.5) - 2025-12-17

### Other

- Optimize more functions with in-place mutations
- Optimize array sorting with in-place operations ([#14](https://github.com/oxc-project/sort-package-json/pull/14))
- Use unstable sort for better performance ([#13](https://github.com/oxc-project/sort-package-json/pull/13))
- Sort files field with natural path sorting ([#10](https://github.com/oxc-project/sort-package-json/pull/10))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).