### PR TITLE
Use unstable sort for better performance

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,7 +167,7 @@ fn sort_array_unique(arr: Vec<Value>) -> Vec<Value> {
     let mut strings: Vec<String> =
         arr.iter().filter_map(|v| v.as_str().map(String::from)).collect();
 
-    strings.sort();
+    strings.sort_unstable();
     strings.dedup();
 
     strings.into_iter().map(Value::String).collect()
@@ -178,11 +178,11 @@ fn sort_paths_naturally(arr: Vec<Value>) -> Vec<Value> {
         arr.iter().filter_map(|v| v.as_str().map(String::from)).collect();
 
     // Remove duplicates first (case-sensitive)
-    strings.sort();
+    strings.sort_unstable();
     strings.dedup();
 
     // Sort by depth first, then alphabetically (case-insensitive)
-    strings.sort_by(|a, b| {
+    strings.sort_unstable_by(|a, b| {
         let depth_a = a.matches('/').count();
         let depth_b = b.matches('/').count();
 


### PR DESCRIPTION
## Summary

- Use `sort_unstable()` and `sort_unstable_by()` instead of stable sort variants for better performance

## Motivation

Stable sorting maintains the relative order of equal elements, but this is unnecessary for our use cases:
- `sort_array_unique()`: Removes duplicates after sorting, so original order doesn't matter
- `sort_paths_naturally()`: Sorts by depth and alphabetically, no need to preserve original order

Using unstable sort provides better performance (faster and uses less memory) without changing behavior.

## Changes

- Replace `sort()` with `sort_unstable()` in `sort_array_unique()`
- Replace `sort_by()` with `sort_unstable_by()` in `sort_paths_naturally()`

## Testing

- All existing tests pass
- No behavioral changes, only performance improvement