### PR TITLE
chore: release v0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.6](https://github.com/oxc-project/sort-package-json/compare/v0.0.5...v0.0.6) - 2025-12-26
+
+### Fixed
+
+- do not sort contributors nor maintainers because they can prioritized
+
+### Other
+
+- rewrite integration tests with comprehensive fixture
+- Replace field ordering list with annotated JSONC example
+- Update README with library API usage and example runner
+- Add explicit compatibility note to README ([#17](https://github.com/oxc-project/sort-package-json/pull/17))
+- Condense 'Why Not simd-json?' section to bullet points
+
 ## [0.0.5](https://github.com/oxc-project/sort-package-json/compare/v0.0.4...v0.0.5) - 2025-12-17
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "sort-package-json"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "criterion2",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sort-package-json"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["Boshen <boshenc@gmail.com>"]
 categories = []
 edition = "2021"


### PR DESCRIPTION



## 🤖 New release

* `sort-package-json`: 0.0.5 -> 0.0.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.6](https://github.com/oxc-project/sort-package-json/compare/v0.0.5...v0.0.6) - 2025-12-26

### Fixed

- do not sort contributors nor maintainers because they can prioritized

### Other

- rewrite integration tests with comprehensive fixture
- Replace field ordering list with annotated JSONC example
- Update README with library API usage and example runner
- Add explicit compatibility note to README ([#17](https://github.com/oxc-project/sort-package-json/pull/17))
- Condense 'Why Not simd-json?' section to bullet points
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).