### PR TITLE
feat: add `sort_scripts` option to sort scripts field alphabetically

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,18 +1,22 @@
-use sort_package_json::sort_package_json;
+use sort_package_json::{SortOptions, sort_package_json_with_options};
 use std::fs;
+
+fn sort(s: &str) -> String {
+    sort_package_json_with_options(s, &SortOptions { pretty: true, sort_scripts: true })
+        .expect("Failed to parse package.json")
+}
 
 #[test]
 fn test_sort_package_json() {
     let input = fs::read_to_string("tests/fixtures/package.json").expect("Failed to read fixture");
-    let result = sort_package_json(&input).expect("Failed to parse package.json");
+    let result = sort(&input);
     insta::assert_snapshot!(result);
 }
 
 #[test]
 fn test_idempotency() {
     let input = fs::read_to_string("tests/fixtures/package.json").expect("Failed to read fixture");
-    let first_sort = sort_package_json(&input).expect("Failed to parse package.json on first sort");
-    let second_sort =
-        sort_package_json(&first_sort).expect("Failed to parse package.json on second sort");
+    let first_sort = sort(&input);
+    let second_sort = sort(&first_sort);
     assert_eq!(first_sort, second_sort, "Sorting should be idempotent");
 }

--- a/tests/snapshots/integration_test__sort_package_json.snap
+++ b/tests/snapshots/integration_test__sort_package_json.snap
@@ -108,12 +108,12 @@ expression: result
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "test": "jest",
-    "posttest": "echo 'Tests complete'",
     "build": "webpack",
+    "dev": "webpack serve",
     "lint": "eslint .",
+    "posttest": "echo 'Tests complete'",
     "pretest": "echo 'Starting tests'",
-    "dev": "webpack serve"
+    "test": "jest"
   },
   "dependencies": {
     "axios": "^1.0.0",


### PR DESCRIPTION
## Summary

- Add a new `sort_scripts` option to `SortOptions` that enables alphabetical sorting of the `scripts` and `betterScripts` fields
- Default is `false` to maintain backward compatibility

## Usage

```rust
let options = SortOptions {
    pretty: true,
    sort_scripts: true,  // Enable script sorting
};
let result = sort_package_json_with_options(input, &options)?;
```

Closes https://github.com/oxc-project/oxc/issues/17387

🤖 Generated with [Claude Code](https://claude.com/claude-code)