### PR TITLE
chore: release v0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.11](https://github.com/oxc-project/sort-package-json/compare/v0.0.10...v0.0.11) - 2026-03-04
+
+### Added
+
+- support vite-staged and stage-tool key ordering ([#63](https://github.com/oxc-project/sort-package-json/pull/63))
+
+### Other
+
+- reduce allocations in sorting pipeline ([#65](https://github.com/oxc-project/sort-package-json/pull/65))
+
 ## [0.0.10](https://github.com/oxc-project/sort-package-json/compare/v0.0.9...v0.0.10) - 2026-01-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,7 +533,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "sort-package-json"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "criterion2",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sort-package-json"
-version = "0.0.10"
+version = "0.0.11"
 authors = ["Boshen <boshenc@gmail.com>"]
 categories = []
 edition = "2021"


### PR DESCRIPTION



## 🤖 New release

* `sort-package-json`: 0.0.10 -> 0.0.11 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.11](https://github.com/oxc-project/sort-package-json/compare/v0.0.10...v0.0.11) - 2026-03-04

### Added

- support vite-staged and stage-tool key ordering ([#63](https://github.com/oxc-project/sort-package-json/pull/63))

### Other

- reduce allocations in sorting pipeline ([#65](https://github.com/oxc-project/sort-package-json/pull/65))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).