### PR TITLE
fix: preserve `exports` and `imports` key order

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A Rust implementation that sorts package.json files according to well-establishe
 
 - **Sorts top-level fields** according to npm ecosystem conventions (138 predefined fields)
 - **Preserves all data** - only reorders fields, never modifies values
+- **Respects semantics** - `exports` and `imports` fields preserve their key order (first-match resolution)
 - **Fast and safe** - pure Rust implementation with no unsafe code
 - **Idempotent** - sorting multiple times produces the same result
 - **Handles edge cases** - unknown fields sorted alphabetically, private fields (starting with `_`) sorted last
@@ -134,14 +135,8 @@ Fields are sorted into 12 logical groups, followed by unknown fields alphabetica
   "module": "./dist/index.mjs",
   "browser": "./dist/browser.js",
   "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs",
-      "default": "./dist/index.mjs",
-    },
-  },
+  "imports": { /* preserved as-is (order has meaning per spec) */ },
+  "exports": { /* preserved as-is (order has meaning per spec) */ },
   "publishConfig": { "access": "public", "registry": "https://registry.npmjs.org" },
 
   // 6. Scripts

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,63 +226,6 @@ fn sort_people_object(obj: Map<String, Value>) -> Map<String, Value> {
     sort_object_by_key_order(obj, &["name", "email", "url"])
 }
 
-fn sort_exports(obj: Map<String, Value>) -> Map<String, Value> {
-    let obj_len = obj.len();
-    let mut paths = Vec::new();
-    let mut types_conds = Vec::new();
-    let mut other_conds = Vec::new();
-    let mut default_cond = None;
-
-    for (key, value) in obj {
-        if key.starts_with('.') {
-            paths.push((key, value));
-        } else if key == "default" {
-            default_cond = Some((key, value));
-        } else if key == "types" || key.starts_with("types@") {
-            types_conds.push((key, value));
-        } else {
-            other_conds.push((key, value));
-        }
-    }
-
-    let mut result = Map::with_capacity(obj_len);
-
-    // Add in order: paths, types, others, default
-    for (key, value) in paths {
-        let transformed = match value {
-            Value::Object(nested) => Value::Object(sort_exports(nested)),
-            _ => value,
-        };
-        result.insert(key, transformed);
-    }
-
-    for (key, value) in types_conds {
-        let transformed = match value {
-            Value::Object(nested) => Value::Object(sort_exports(nested)),
-            _ => value,
-        };
-        result.insert(key, transformed);
-    }
-
-    for (key, value) in other_conds {
-        let transformed = match value {
-            Value::Object(nested) => Value::Object(sort_exports(nested)),
-            _ => value,
-        };
-        result.insert(key, transformed);
-    }
-
-    if let Some((key, value)) = default_cond {
-        let transformed = match value {
-            Value::Object(nested) => Value::Object(sort_exports(nested)),
-            _ => value,
-        };
-        result.insert(key, transformed);
-    }
-
-    result
-}
-
 fn sort_object_keys(obj: Map<String, Value>, options: &SortOptions) -> Map<String, Value> {
     // Storage for categorized keys with their values and ordering information
     let mut known: Vec<(usize, String, Value)> = Vec::new(); // (order_index, key, value)
@@ -361,7 +304,7 @@ fn sort_object_keys(obj: Map<String, Value>, options: &SortOptions) -> Map<Strin
             61 => "fesm2020",
             62 => "esnext",
             63 => "imports",
-            64 => "exports" => transform_value(value, sort_exports),
+            64 => "exports",
             65 => "publishConfig" => transform_value(value, sort_object_alphabetically),
             // Scripts
             66 => "scripts" => if options.sort_scripts { transform_value(value, sort_object_alphabetically) } else { value },

--- a/tests/snapshots/integration_test__sort_package_json.snap
+++ b/tests/snapshots/integration_test__sort_package_json.snap
@@ -86,10 +86,10 @@ expression: result
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js",
       "require": "./dist/index.cjs",
-      "import": "./dist/index.esm.js",
-      "default": "./dist/index.js"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.esm.js"
     },
     "./paths-should-keep-b_a": {
       "b": "./index.cjs",
@@ -97,9 +97,9 @@ expression: result
     },
     "./package.json": "./package.json",
     "./utils": {
-      "types": "./dist/utils.d.ts",
       "import": "./dist/utils.esm.js",
-      "default": "./dist/utils.js"
+      "default": "./dist/utils.js",
+      "types": "./dist/utils.d.ts"
     }
   },
   "publishConfig": {


### PR DESCRIPTION
## Summary

- Stop sorting `exports` field condition keys — their order has meaning per the Node.js spec (first-match resolution semantics)
- `imports` was already unsorted; this change makes the intent explicit
- Updated README to document this behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)