### PR TITLE
feat: add sort_order option for custom field ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ With custom options:
 ```rust
 use sort_package_json::{sort_package_json_with_options, SortOptions};
 
-let options = SortOptions { pretty: false };
+let options = SortOptions { pretty: false, ..SortOptions::default() };
 let sorted = sort_package_json_with_options(&contents, &options)?;
 ```
 
@@ -190,6 +190,24 @@ Fields are sorted into 12 logical groups, followed by unknown fields alphabetica
   "_private": "data",
 }
 ```
+
+## Custom Field Order
+
+The `sort_order` option lets you control which fields appear first. Fields listed in `sort_order` are placed at the top in the given order, followed by the remaining known fields in their default order. Unknown and private fields not in the list keep their default placement.
+
+```rust
+use sort_package_json::{sort_package_json_with_options, SortOptions};
+
+let options = SortOptions {
+    sort_order: vec![
+        "name", "version", "description", "scripts",
+    ].into_iter().map(String::from).collect(),
+    ..SortOptions::default()
+};
+let sorted = sort_package_json_with_options(&contents, &options)?;
+```
+
+This is useful when you prefer certain fields like `scripts` near the top of your `package.json` for quick access.
 
 ## Why Not simd-json?
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde_json::{Map, Value};
 
 /// Options for controlling JSON formatting when sorting
@@ -7,11 +9,19 @@ pub struct SortOptions {
     pub pretty: bool,
     /// Whether to sort the scripts field alphabetically
     pub sort_scripts: bool,
+    /// Custom top-level field ordering.
+    ///
+    /// Fields listed here appear first in the specified order, followed by
+    /// remaining known fields in their default order. Unknown and private
+    /// fields not in this list keep their default placement.
+    ///
+    /// An empty list (default) preserves the built-in ordering.
+    pub sort_order: Vec<String>,
 }
 
 impl Default for SortOptions {
     fn default() -> Self {
-        Self { pretty: true, sort_scripts: false }
+        Self { pretty: true, sort_scripts: false, sort_order: Vec::new() }
     }
 }
 
@@ -387,6 +397,48 @@ fn sort_object_keys(obj: Map<String, Value>, options: &SortOptions) -> Map<Strin
             137 => "packageManager",
             138 => "pnpm",
         ]);
+    }
+
+    // Apply custom sort_order: re-index fields and promote unknown/private fields
+    if !options.sort_order.is_empty() {
+        let mut order_map: HashMap<&str, usize> =
+            HashMap::with_capacity(options.sort_order.len());
+        for (i, name) in options.sort_order.iter().enumerate() {
+            order_map.entry(name.as_str()).or_insert(i); // first occurrence wins
+        }
+
+        let sort_order_len = order_map.len();
+
+        // Re-index known fields
+        for item in &mut known {
+            if let Some(&pos) = order_map.get(item.1.as_str()) {
+                item.0 = pos;
+            } else {
+                item.0 = sort_order_len + item.0;
+            }
+        }
+
+        // Promote non-private unknown fields that are in sort_order
+        let mut remaining_non_private = Vec::new();
+        for (key, value) in non_private {
+            if let Some(&pos) = order_map.get(key.as_str()) {
+                known.push((pos, key, value));
+            } else {
+                remaining_non_private.push((key, value));
+            }
+        }
+        non_private = remaining_non_private;
+
+        // Promote private fields that are in sort_order
+        let mut remaining_private = Vec::new();
+        for (key, value) in private {
+            if let Some(&pos) = order_map.get(key.as_str()) {
+                known.push((pos, key, value));
+            } else {
+                remaining_private.push((key, value));
+            }
+        }
+        private = remaining_private;
     }
 
     // Sort each category (using unstable sort for better performance)

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,8 +3,23 @@ use sort_package_json::{SortOptions, sort_package_json_with_options};
 use std::fs;
 
 fn sort(s: &str) -> String {
-    sort_package_json_with_options(s, &SortOptions { pretty: true, sort_scripts: true })
-        .expect("Failed to parse package.json")
+    sort_package_json_with_options(
+        s,
+        &SortOptions { pretty: true, sort_scripts: true, ..SortOptions::default() },
+    )
+    .expect("Failed to parse package.json")
+}
+
+fn sort_with_order(s: &str, sort_order: Vec<&str>) -> String {
+    sort_package_json_with_options(
+        s,
+        &SortOptions {
+            pretty: true,
+            sort_scripts: true,
+            sort_order: sort_order.into_iter().map(String::from).collect(),
+        },
+    )
+    .expect("Failed to parse package.json")
 }
 
 #[test]
@@ -95,4 +110,103 @@ fn test_utf8_bom_preservation() {
     // Test 3: Idempotency - sorting twice produces same result
     let second_sort = sort(&result);
     assert_eq!(result, second_sort, "Sorting BOM files should be idempotent");
+}
+
+#[test]
+fn test_sort_order_basic() {
+    let input = r#"{
+  "dependencies": { "b": "1", "a": "2" },
+  "version": "1.0.0",
+  "scripts": { "build": "tsc", "dev": "vite" },
+  "name": "test",
+  "description": "A test package"
+}"#;
+    let result = sort_with_order(input, vec!["name", "version", "description", "scripts"]);
+    insta::assert_snapshot!(result);
+}
+
+#[test]
+fn test_sort_order_promotes_unknown_field() {
+    let input = r#"{
+  "version": "1.0.0",
+  "name": "test",
+  "myCustomField": "hello",
+  "description": "A test package"
+}"#;
+    let result = sort_with_order(input, vec!["name", "myCustomField", "version"]);
+    insta::assert_snapshot!(result);
+}
+
+#[test]
+fn test_sort_order_promotes_private_field() {
+    let input = r#"{
+  "version": "1.0.0",
+  "name": "test",
+  "_id": "internal"
+}"#;
+    let result = sort_with_order(input, vec!["name", "_id", "version"]);
+    insta::assert_snapshot!(result);
+}
+
+#[test]
+fn test_sort_order_preserves_transforms() {
+    let input = r#"{
+  "name": "test",
+  "dependencies": { "zod": "3", "axios": "1", "react": "18" }
+}"#;
+    // dependencies should still be sorted alphabetically even when promoted
+    let result = sort_with_order(input, vec!["dependencies", "name"]);
+    insta::assert_snapshot!(result);
+}
+
+#[test]
+fn test_sort_order_empty_is_noop() {
+    let input = r#"{
+  "version": "1.0.0",
+  "name": "test",
+  "description": "A test package"
+}"#;
+    let default_result = sort(input);
+    let with_empty_order = sort_with_order(input, vec![]);
+    assert_eq!(default_result, with_empty_order, "Empty sort_order should be a no-op");
+}
+
+#[test]
+fn test_sort_order_missing_fields_skipped() {
+    let input = r#"{
+  "version": "1.0.0",
+  "name": "test"
+}"#;
+    let result = sort_with_order(input, vec!["name", "nonexistent", "also_missing", "version"]);
+    let parsed: Value = serde_json::from_str(&result).unwrap();
+    let keys: Vec<&str> = parsed.as_object().unwrap().keys().map(|k| k.as_str()).collect();
+    assert_eq!(keys, vec!["name", "version"]);
+}
+
+#[test]
+fn test_sort_order_duplicates() {
+    let input = r#"{
+  "version": "1.0.0",
+  "name": "test",
+  "description": "A test package"
+}"#;
+    // "name" appears twice — first occurrence (position 0) should win
+    let result = sort_with_order(input, vec!["name", "version", "name", "description"]);
+    let parsed: Value = serde_json::from_str(&result).unwrap();
+    let keys: Vec<&str> = parsed.as_object().unwrap().keys().map(|k| k.as_str()).collect();
+    assert_eq!(keys, vec!["name", "version", "description"]);
+}
+
+#[test]
+fn test_sort_order_idempotency() {
+    let input = r#"{
+  "dependencies": { "b": "1", "a": "2" },
+  "version": "1.0.0",
+  "scripts": { "build": "tsc" },
+  "name": "test"
+}"#;
+    let order = vec!["name", "version", "scripts"];
+    let first = sort_with_order(input, order.clone());
+    let second = sort_with_order(&first, order);
+    assert_eq!(first, second, "Sorting with sort_order should be idempotent");
 }

--- a/tests/snapshots/integration_test__sort_order_basic.snap
+++ b/tests/snapshots/integration_test__sort_order_basic.snap
@@ -1,0 +1,17 @@
+---
+source: tests/integration_test.rs
+expression: result
+---
+{
+  "name": "test",
+  "version": "1.0.0",
+  "description": "A test package",
+  "scripts": {
+    "build": "tsc",
+    "dev": "vite"
+  },
+  "dependencies": {
+    "a": "2",
+    "b": "1"
+  }
+}

--- a/tests/snapshots/integration_test__sort_order_preserves_transforms.snap
+++ b/tests/snapshots/integration_test__sort_order_preserves_transforms.snap
@@ -1,0 +1,12 @@
+---
+source: tests/integration_test.rs
+expression: result
+---
+{
+  "dependencies": {
+    "axios": "1",
+    "react": "18",
+    "zod": "3"
+  },
+  "name": "test"
+}

--- a/tests/snapshots/integration_test__sort_order_promotes_private_field.snap
+++ b/tests/snapshots/integration_test__sort_order_promotes_private_field.snap
@@ -1,0 +1,9 @@
+---
+source: tests/integration_test.rs
+expression: result
+---
+{
+  "name": "test",
+  "_id": "internal",
+  "version": "1.0.0"
+}

--- a/tests/snapshots/integration_test__sort_order_promotes_unknown_field.snap
+++ b/tests/snapshots/integration_test__sort_order_promotes_unknown_field.snap
@@ -1,0 +1,10 @@
+---
+source: tests/integration_test.rs
+expression: result
+---
+{
+  "name": "test",
+  "myCustomField": "hello",
+  "version": "1.0.0",
+  "description": "A test package"
+}


### PR DESCRIPTION
Adds a `sort_order` option to `SortOptions` that allows users to specify a custom top-level field ordering for package.json.

Fields listed in `sort_order` appear first in the specified order, followed by remaining known fields in their default order. This enables use cases like moving `scripts` near the top of package.json for quick access.

```rust
let options = SortOptions {
    sort_order: vec!["name", "version", "description", "scripts"]
        .into_iter().map(String::from).collect(),
    ..SortOptions::default()
};
```

Behavior:

- Empty `sort_order` (default) preserves the built-in ordering — fully backward compatible
- Unknown fields in the list get promoted into the ordered position
- Private (`_`-prefixed) fields in the list get promoted as well
- Missing fields are silently skipped
- Duplicates are handled (first occurrence wins)
- Field transformations (e.g. alphabetical sorting of `dependencies`) are preserved regardless of position

## AI Disclosure

This PR was authored with assistance from Claude Code (Claude Opus 4.6). All code has been reviewed, tested, and validated by me (@Shinigami92) before submission.

Prepare for https://github.com/oxc-project/oxc/issues/21014
