### PR TITLE
fix: deep-sort publishConfig with the same field order as package.json

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,7 +305,7 @@ fn sort_object_keys(obj: Map<String, Value>, options: &SortOptions) -> Map<Strin
             62 => "esnext",
             63 => "imports",
             64 => "exports",
-            65 => "publishConfig" => transform_value(value, sort_object_alphabetically),
+            65 => "publishConfig" => transform_value(value, |o| sort_object_keys(o, options)),
             // Scripts
             66 => "scripts" => if options.sort_scripts { transform_value(value, sort_object_alphabetically) } else { value },
             67 => "betterScripts" => if options.sort_scripts { transform_value(value, sort_object_alphabetically) } else { value },

--- a/tests/fixtures/package.json
+++ b/tests/fixtures/package.json
@@ -93,7 +93,15 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "tag": "latest",
+    "types": "./dist/index.d.ts",
+    "main": "./dist/index.js",
+    "name": "@scope/published-name",
+    "dependencies": {
+      "react": "^18.0.0",
+      "axios": "^1.0.0"
+    }
   },
   "scripts": {
     "test": "jest",

--- a/tests/snapshots/integration_test__sort_package_json.snap
+++ b/tests/snapshots/integration_test__sort_package_json.snap
@@ -103,8 +103,16 @@ expression: result
     }
   },
   "publishConfig": {
+    "name": "@scope/published-name",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "dependencies": {
+      "axios": "^1.0.0",
+      "react": "^18.0.0"
+    },
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "tag": "latest"
   },
   "scripts": {
     "build": "webpack",


### PR DESCRIPTION
## Summary
- Closes #71.
- `publishConfig` now recurses through `sort_object_keys`, so its fields follow the canonical package.json order (e.g. `name` → `main` → `types` → `dependencies` → unknown fields alphabetically) instead of a flat alphabetical sort.
- Fixture and snapshot expanded to exercise the new behavior with `name`, `main`, `types`, `tag`, and a nested `dependencies`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)