### PR TITLE
fix: top-level sort for jest, tshy, remarkConfig, and auto-changelog

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,17 +328,21 @@ fn sort_object_keys(obj: Map<String, Value>, options: &SortOptions) -> Map<Strin
             110 => "npmPackageJsonLintConfig",
             111 => "npmpackagejsonlint",
             112 => "release",
-            113 => "auto-changelog" => transform_value(value, sort_object_recursive),
-            114 => "remarkConfig" => transform_value(value, sort_object_recursive),
+            // Only sorts top-level keys: `replaceText` maps regexes to replacements applied sequentially in key order
+            113 => "auto-changelog" => transform_value(value, sort_object_alphabetically),
+            // Only sorts top-level keys: `plugins` in object form runs plugins in key order
+            114 => "remarkConfig" => transform_value(value, sort_object_alphabetically),
             115 => "stylelint" => transform_value(value, sort_object_recursive),
             116 => "typescript" => transform_value(value, sort_object_recursive),
             117 => "typedoc" => transform_value(value, sort_object_recursive),
-            118 => "tshy" => transform_value(value, sort_object_recursive),
+            // Only sorts top-level keys: `exports` values may be pass-through conditional exports
+            118 => "tshy" => transform_value(value, sort_object_alphabetically),
             119 => "tsdown" => transform_value(value, sort_object_recursive),
             120 => "size-limit",
             // Testing
             121 => "ava" => transform_value(value, sort_object_recursive),
-            122 => "jest" => transform_value(value, sort_object_recursive),
+            // Only sorts top-level keys: nested config like `moduleNameMapper` is order-dependent
+            122 => "jest" => transform_value(value, sort_object_alphabetically),
             123 => "jest-junit",
             124 => "jest-stare",
             125 => "mocha" => transform_value(value, sort_object_recursive),

--- a/tests/fixtures/package.json
+++ b/tests/fixtures/package.json
@@ -159,9 +159,40 @@
     "singleQuote": true,
     "semi": false
   },
+  "auto-changelog": {
+    "unreleased": true,
+    "replaceText": {
+      "(ABC-\\d+)": "[`$1`](https://issues.example.com/$1)",
+      "\\[`(ABC-\\d+)`\\]\\(.*\\) hotfix": "HOTFIX $1"
+    }
+  },
+  "remarkConfig": {
+    "settings": {
+      "bullet": "-"
+    },
+    "plugins": {
+      "remark-toc": true,
+      "remark-lint": true
+    }
+  },
+  "tshy": {
+    "selfLink": false,
+    "exports": {
+      ".": "./src/index.ts",
+      "./compiled": {
+        "types": "./lib/compiled.d.ts",
+        "import": "./lib/compiled.mjs",
+        "default": "./lib/compiled.cjs"
+      }
+    }
+  },
   "jest": {
     "testEnvironment": "node",
-    "collectCoverage": true
+    "collectCoverage": true,
+    "moduleNameMapper": {
+      "^_/(.*).(woff|woff2)$": "<rootDir>/assets/test/fileMock.js",
+      "^_/(.*)$": "<rootDir>/src/$1"
+    }
   },
   "engines": {
     "npm": ">=8.0.0",

--- a/tests/snapshots/integration_test__sort_package_json.snap
+++ b/tests/snapshots/integration_test__sort_package_json.snap
@@ -183,8 +183,39 @@ expression: result
       "eslint:recommended"
     ]
   },
+  "auto-changelog": {
+    "replaceText": {
+      "(ABC-\\d+)": "[`$1`](https://issues.example.com/$1)",
+      "\\[`(ABC-\\d+)`\\]\\(.*\\) hotfix": "HOTFIX $1"
+    },
+    "unreleased": true
+  },
+  "remarkConfig": {
+    "plugins": {
+      "remark-toc": true,
+      "remark-lint": true
+    },
+    "settings": {
+      "bullet": "-"
+    }
+  },
+  "tshy": {
+    "exports": {
+      ".": "./src/index.ts",
+      "./compiled": {
+        "types": "./lib/compiled.d.ts",
+        "import": "./lib/compiled.mjs",
+        "default": "./lib/compiled.cjs"
+      }
+    },
+    "selfLink": false
+  },
   "jest": {
     "collectCoverage": true,
+    "moduleNameMapper": {
+      "^_/(.*).(woff|woff2)$": "<rootDir>/assets/test/fileMock.js",
+      "^_/(.*)$": "<rootDir>/src/$1"
+    },
     "testEnvironment": "node"
   },
   "engines": {


### PR DESCRIPTION
Fixes #137

For fields where the order of declaration is significant, only sort at the top level.