### PR TITLE
chore: reduce Rust dev debug info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,3 +74,9 @@ codegen-units = 1
 strip = "symbols" # set to `false` for debug information
 debug = false # set to `true` for debug information
 panic = "abort" # Let it crash and force ourselves to write safe Rust.
+
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+debug = false


### PR DESCRIPTION
Reduces debug information for local Rust builds and disables debug information for dependencies.