### PR TITLE
fix: sort devEngines descriptor fields

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,24 @@ fn sort_people_object(obj: Map<String, Value>) -> Map<String, Value> {
     sort_object_by_key_order(obj, &["name", "email", "url"])
 }
 
+fn sort_dev_engine(value: Value) -> Value {
+    const KEY_ORDER: &[&str] = &["name", "version", "onFail"];
+
+    match value {
+        Value::Array(arr) => Value::Array(
+            arr.into_iter().map(|value| transform_with_key_order(value, KEY_ORDER)).collect(),
+        ),
+        other => transform_with_key_order(other, KEY_ORDER),
+    }
+}
+
+fn sort_dev_engines(obj: Map<String, Value>) -> Map<String, Value> {
+    let mut obj: Map<String, Value> =
+        obj.into_iter().map(|(key, value)| (key, sort_dev_engine(value))).collect();
+    obj.sort_keys();
+    obj
+}
+
 // ===== Top-level field ordering =============================================
 
 /// Declares the canonical order for known top-level `package.json` fields. For each
@@ -355,7 +373,7 @@ fn sort_object_keys(obj: Map<String, Value>, options: &SortOptions) -> Map<Strin
             // Runtime & Package Manager
             132 => "languageName",
             133 => "preferGlobal",
-            134 => "devEngines" => transform_value(value, sort_object_alphabetically),
+            134 => "devEngines" => transform_value(value, sort_dev_engines),
             135 => "engines" => transform_value(value, sort_object_alphabetically),
             136 => "engineStrict",
             137 => "volta" => transform_value(value, sort_object_recursive),

--- a/tests/fixtures/package.json
+++ b/tests/fixtures/package.json
@@ -194,6 +194,16 @@
       "^_/(.*)$": "<rootDir>/src/$1"
     }
   },
+  "devEngines": {
+    "runtime": { "onFail": "download", "name": "node", "version": "1.0.0" },
+    "libc": [{ "version": ">=2.31", "onFail": "warn", "name": "glibc" }],
+    "os": [
+      { "onFail": "warn", "version": ">=14", "name": "darwin" },
+      { "version": ">=10", "name": "win32" }
+    ],
+    "packageManager": { "version": "1.0.0", "name": "pnpm", "onFail": "download" },
+    "cpu": { "onFail": "ignore", "name": "x64" }
+  },
   "engines": {
     "npm": ">=8.0.0",
     "node": ">=18.0.0"

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -70,64 +70,6 @@ fn test_size_limit_preservation() {
 }
 
 #[test]
-fn test_dev_engines_sorting() {
-    let input = r#"{
-  "name": "test",
-  "devEngines": {
-    "runtime": { "onFail": "download", "name": "node", "version": "1.0.0" },
-    "libc": [{ "version": ">=2.31", "onFail": "warn", "name": "glibc" }],
-    "os": [
-      { "onFail": "warn", "version": ">=14", "name": "darwin" },
-      { "version": ">=10", "name": "win32" }
-    ],
-    "packageManager": { "version": "1.0.0", "name": "pnpm", "onFail": "download" },
-    "cpu": { "onFail": "ignore", "name": "x64" }
-  }
-}"#;
-
-    let expected = r#"{
-  "name": "test",
-  "devEngines": {
-    "cpu": {
-      "name": "x64",
-      "onFail": "ignore"
-    },
-    "libc": [
-      {
-        "name": "glibc",
-        "version": ">=2.31",
-        "onFail": "warn"
-      }
-    ],
-    "os": [
-      {
-        "name": "darwin",
-        "version": ">=14",
-        "onFail": "warn"
-      },
-      {
-        "name": "win32",
-        "version": ">=10"
-      }
-    ],
-    "packageManager": {
-      "name": "pnpm",
-      "version": "1.0.0",
-      "onFail": "download"
-    },
-    "runtime": {
-      "name": "node",
-      "version": "1.0.0",
-      "onFail": "download"
-    }
-  }
-}
-"#;
-
-    assert_eq!(sort(input), expected);
-}
-
-#[test]
 fn test_utf8_bom_preservation() {
     // Test case based on https://github.com/vitejs/vite/blob/main/playground/resolve/utf8-bom-package/package.json
     const BOM: char = '\u{FEFF}';

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -70,6 +70,64 @@ fn test_size_limit_preservation() {
 }
 
 #[test]
+fn test_dev_engines_sorting() {
+    let input = r#"{
+  "name": "test",
+  "devEngines": {
+    "runtime": { "onFail": "download", "name": "node", "version": "1.0.0" },
+    "libc": [{ "version": ">=2.31", "onFail": "warn", "name": "glibc" }],
+    "os": [
+      { "onFail": "warn", "version": ">=14", "name": "darwin" },
+      { "version": ">=10", "name": "win32" }
+    ],
+    "packageManager": { "version": "1.0.0", "name": "pnpm", "onFail": "download" },
+    "cpu": { "onFail": "ignore", "name": "x64" }
+  }
+}"#;
+
+    let expected = r#"{
+  "name": "test",
+  "devEngines": {
+    "cpu": {
+      "name": "x64",
+      "onFail": "ignore"
+    },
+    "libc": [
+      {
+        "name": "glibc",
+        "version": ">=2.31",
+        "onFail": "warn"
+      }
+    ],
+    "os": [
+      {
+        "name": "darwin",
+        "version": ">=14",
+        "onFail": "warn"
+      },
+      {
+        "name": "win32",
+        "version": ">=10"
+      }
+    ],
+    "packageManager": {
+      "name": "pnpm",
+      "version": "1.0.0",
+      "onFail": "download"
+    },
+    "runtime": {
+      "name": "node",
+      "version": "1.0.0",
+      "onFail": "download"
+    }
+  }
+}
+"#;
+
+    assert_eq!(sort(input), expected);
+}
+
+#[test]
 fn test_utf8_bom_preservation() {
     // Test case based on https://github.com/vitejs/vite/blob/main/playground/resolve/utf8-bom-package/package.json
     const BOM: char = '\u{FEFF}';

--- a/tests/snapshots/integration_test__sort_package_json.snap
+++ b/tests/snapshots/integration_test__sort_package_json.snap
@@ -218,6 +218,40 @@ expression: result
     },
     "testEnvironment": "node"
   },
+  "devEngines": {
+    "cpu": {
+      "name": "x64",
+      "onFail": "ignore"
+    },
+    "libc": [
+      {
+        "name": "glibc",
+        "version": ">=2.31",
+        "onFail": "warn"
+      }
+    ],
+    "os": [
+      {
+        "name": "darwin",
+        "version": ">=14",
+        "onFail": "warn"
+      },
+      {
+        "name": "win32",
+        "version": ">=10"
+      }
+    ],
+    "packageManager": {
+      "name": "pnpm",
+      "version": "1.0.0",
+      "onFail": "download"
+    },
+    "runtime": {
+      "name": "node",
+      "version": "1.0.0",
+      "onFail": "download"
+    }
+  },
   "engines": {
     "node": ">=18.0.0",
     "npm": ">=8.0.0"


### PR DESCRIPTION
Sort `devEngines` descriptor objects in npm's documented `name`, `version`, `onFail` order. The previous transform only sorted the top-level keys.

Supports both object and array forms. Validated with `cargo test` and `cargo clippy`.

Fixes #154.
