### PR TITLE
perf: borrow JSON strings during sorting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,12 +212,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,12 +287,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
 name = "ignore"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,16 +300,6 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
-dependencies = [
- "equivalent",
- "hashbrown",
 ]
 
 [[package]]
@@ -504,7 +482,6 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
- "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -531,6 +508,7 @@ dependencies = [
  "criterion2",
  "ignore",
  "insta",
+ "serde",
  "serde_json",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,8 @@ undocumented_unsafe_blocks = "warn"
 infinite_loop = "warn"
 
 [dependencies]
-serde_json = { version = "1.0", features = ["preserve_order"] }
+serde = "1.0"
+serde_json = "1.0"
 
 [dev-dependencies]
 criterion2 = { version = "3", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,8 @@
-use serde_json::{Map, Value};
+mod value;
+
+use std::borrow::Cow;
+
+use value::{Object, Value};
 
 /// UTF-8 BOM (`U+FEFF`).
 const BOM_STR: &str = "\u{FEFF}";
@@ -26,7 +30,7 @@ pub fn sort_package_json_with_options(
     let (has_bom, body) =
         input.strip_prefix(BOM_STR).map_or((false, input), |stripped| (true, stripped));
 
-    let value: Value = serde_json::from_str(body)?;
+    let value: Value<'_> = serde_json::from_str(body)?;
 
     let sorted = match value {
         Value::Object(obj) => Value::Object(sort_object_keys(obj, options)),
@@ -65,9 +69,9 @@ pub fn sort_package_json(input: &str) -> Result<String, serde_json::Error> {
 // ===== Value-level transformations ==========================================
 
 #[inline]
-fn transform_value<F>(value: Value, f: F) -> Value
+fn transform_value<'a, F>(value: Value<'a>, f: F) -> Value<'a>
 where
-    F: FnOnce(Map<String, Value>) -> Map<String, Value>,
+    F: FnOnce(Object<'a>) -> Object<'a>,
 {
     match value {
         Value::Object(o) => Value::Object(f(o)),
@@ -76,9 +80,9 @@ where
 }
 
 #[inline]
-fn transform_array<F>(value: Value, f: F) -> Value
+fn transform_array<'a, F>(value: Value<'a>, f: F) -> Value<'a>
 where
-    F: FnOnce(Vec<Value>) -> Vec<Value>,
+    F: FnOnce(Vec<Value<'a>>) -> Vec<Value<'a>>,
 {
     match value {
         Value::Array(arr) => Value::Array(f(arr)),
@@ -87,31 +91,31 @@ where
 }
 
 #[inline]
-fn transform_with_key_order(value: Value, key_order: &[&str]) -> Value {
+fn transform_with_key_order<'a>(value: Value<'a>, key_order: &[&str]) -> Value<'a> {
     transform_value(value, |o| sort_object_by_key_order(o, key_order))
 }
 
-fn sort_object_alphabetically(mut obj: Map<String, Value>) -> Map<String, Value> {
-    obj.sort_keys();
+fn sort_object_alphabetically(mut obj: Object<'_>) -> Object<'_> {
+    obj.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
     obj
 }
 
-fn sort_object_recursive(mut obj: Map<String, Value>) -> Map<String, Value> {
+fn sort_object_recursive(mut obj: Object<'_>) -> Object<'_> {
     sort_object_recursive_in_place(&mut obj);
     obj
 }
 
-fn sort_object_recursive_in_place(obj: &mut Map<String, Value>) {
-    for value in obj.values_mut() {
+fn sort_object_recursive_in_place(obj: &mut Object<'_>) {
+    for (_, value) in &mut *obj {
         if let Value::Object(nested) = value {
             sort_object_recursive_in_place(nested);
         }
     }
-    obj.sort_keys();
+    obj.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
 }
 
 /// Filters non-strings, sorts ascending, and removes duplicates.
-fn sort_array_unique(mut arr: Vec<Value>) -> Vec<Value> {
+fn sort_array_unique(mut arr: Vec<Value<'_>>) -> Vec<Value<'_>> {
     arr.retain(Value::is_string);
     // `unwrap` is sound: `retain` above guarantees every element is a string.
     arr.sort_unstable_by(|a, b| a.as_str().unwrap().cmp(b.as_str().unwrap()));
@@ -121,7 +125,7 @@ fn sort_array_unique(mut arr: Vec<Value>) -> Vec<Value> {
 
 /// Removes duplicate string entries while preserving original order. Used for fields
 /// where order matters (e.g., `files` with `!` negation patterns).
-fn dedupe_array(mut arr: Vec<Value>) -> Vec<Value> {
+fn dedupe_array(mut arr: Vec<Value<'_>>) -> Vec<Value<'_>> {
     let mut write = 0;
     for read in 0..arr.len() {
         let keep = match arr[read].as_str() {
@@ -142,14 +146,14 @@ fn dedupe_array(mut arr: Vec<Value>) -> Vec<Value> {
 /// Reorders `obj` so that any keys present in `key_order` appear first (in the given
 /// order), with the remaining keys following alphabetically.
 ///
-/// Single-pass classification + merge — avoids `IndexMap::shift_remove`'s O(n) tail-shift
-/// per requested key.
-fn sort_object_by_key_order(obj: Map<String, Value>, key_order: &[&str]) -> Map<String, Value> {
-    let mut known: Vec<Option<(String, Value)>> = (0..key_order.len()).map(|_| None).collect();
-    let mut others: Vec<(String, Value)> = Vec::new();
+/// Single-pass classification followed by an alphabetical sort of unrecognized keys.
+fn sort_object_by_key_order<'a>(obj: Object<'a>, key_order: &[&str]) -> Object<'a> {
+    let mut known: Vec<Option<(Cow<'a, str>, Value<'a>)>> =
+        (0..key_order.len()).map(|_| None).collect();
+    let mut others: Object<'a> = Vec::new();
 
     for (key, value) in obj {
-        match key_order.iter().position(|kn| *kn == key.as_str()) {
+        match key_order.iter().position(|kn| *kn == key.as_ref()) {
             Some(idx) => known[idx] = Some((key, value)),
             None => others.push((key, value)),
         }
@@ -157,21 +161,21 @@ fn sort_object_by_key_order(obj: Map<String, Value>, key_order: &[&str]) -> Map<
 
     others.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
 
-    let mut result = Map::with_capacity(known.len() + others.len());
+    let mut result = Vec::with_capacity(known.len() + others.len());
     for (key, value) in known.into_iter().flatten() {
-        result.insert(key, value);
+        result.push((key, value));
     }
     for (key, value) in others {
-        result.insert(key, value);
+        result.push((key, value));
     }
     result
 }
 
-fn sort_people_object(obj: Map<String, Value>) -> Map<String, Value> {
+fn sort_people_object(obj: Object<'_>) -> Object<'_> {
     sort_object_by_key_order(obj, &["name", "email", "url"])
 }
 
-fn sort_dev_engine(value: Value) -> Value {
+fn sort_dev_engine(value: Value<'_>) -> Value<'_> {
     const KEY_ORDER: &[&str] = &["name", "version", "onFail"];
 
     match value {
@@ -182,10 +186,10 @@ fn sort_dev_engine(value: Value) -> Value {
     }
 }
 
-fn sort_dev_engines(obj: Map<String, Value>) -> Map<String, Value> {
-    let mut obj: Map<String, Value> =
+fn sort_dev_engines(obj: Object<'_>) -> Object<'_> {
+    let mut obj: Object<'_> =
         obj.into_iter().map(|(key, value)| (key, sort_dev_engine(value))).collect();
-    obj.sort_keys();
+    obj.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
     obj
 }
 
@@ -200,7 +204,7 @@ macro_rules! declare_field_order {
         $key:ident, $value:ident, $known:ident, $unknown:ident;
         [ $( $idx:literal => $field_name:literal $( => $transform:expr )? ),* $(,)? ]
     ) => {
-        match $key.as_str() {
+        match $key.as_ref() {
             $(
                 $field_name => $known.push((
                     $idx,
@@ -215,11 +219,11 @@ macro_rules! declare_field_order {
     (@value $value:ident, $transform:expr) => { $transform };
 }
 
-fn sort_object_keys(obj: Map<String, Value>, options: &SortOptions) -> Map<String, Value> {
+fn sort_object_keys<'a>(obj: Object<'a>, options: &SortOptions) -> Object<'a> {
     // `known` collects fields with a canonical position; `unknown` collects everything
     // else, sorted with private (`_`-prefixed) keys after non-private ones.
-    let mut known: Vec<(usize, String, Value)> = Vec::new();
-    let mut unknown: Vec<(String, Value)> = Vec::new();
+    let mut known: Vec<(usize, Cow<'a, str>, Value<'a>)> = Vec::new();
+    let mut unknown: Object<'a> = Vec::new();
 
     for (key, value) in obj {
         declare_field_order!(key, value, known, unknown; [
@@ -391,12 +395,12 @@ fn sort_object_keys(obj: Map<String, Value>, options: &SortOptions) -> Map<Strin
         a_priv.cmp(&b_priv).then_with(|| a.cmp(b))
     });
 
-    let mut result = Map::with_capacity(known.len() + unknown.len());
+    let mut result = Vec::with_capacity(known.len() + unknown.len());
     for (_, key, value) in known {
-        result.insert(key, value);
+        result.push((key, value));
     }
     for (key, value) in unknown {
-        result.insert(key, value);
+        result.push((key, value));
     }
     result
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,0 +1,200 @@
+use std::{borrow::Cow, fmt, marker::PhantomData};
+
+use serde::{
+    Deserialize, Deserializer, Serialize, Serializer,
+    de::{Error, MapAccess, SeqAccess, Visitor},
+    ser::{SerializeMap, SerializeSeq},
+};
+use serde_json::Number;
+
+pub(crate) type Object<'a> = Vec<(Cow<'a, str>, Value<'a>)>;
+
+/// A JSON value that borrows strings without escape sequences from the input.
+///
+/// `serde_json::Value` owns every string and stores objects in an `IndexMap` when
+/// `preserve_order` is enabled. Package manifests are short-lived and are sorted
+/// immediately, so a borrowing `Cow` plus `Vec` representation avoids that work.
+pub(crate) enum Value<'a> {
+    Null,
+    Bool(bool),
+    Number(Number),
+    String(Cow<'a, str>),
+    Array(Vec<Value<'a>>),
+    Object(Object<'a>),
+}
+
+impl Value<'_> {
+    #[inline]
+    pub(crate) fn is_string(&self) -> bool {
+        matches!(self, Self::String(_))
+    }
+
+    #[inline]
+    pub(crate) fn as_str(&self) -> Option<&str> {
+        match self {
+            Self::String(value) => Some(value),
+            _ => None,
+        }
+    }
+}
+
+impl Serialize for Value<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Null => serializer.serialize_unit(),
+            Self::Bool(value) => serializer.serialize_bool(*value),
+            Self::Number(value) => value.serialize(serializer),
+            Self::String(value) => serializer.serialize_str(value),
+            Self::Array(values) => {
+                let mut seq = serializer.serialize_seq(Some(values.len()))?;
+                for value in values {
+                    seq.serialize_element(value)?;
+                }
+                seq.end()
+            }
+            Self::Object(entries) => {
+                let mut map = serializer.serialize_map(Some(entries.len()))?;
+                for (key, value) in entries {
+                    map.serialize_entry(key, value)?;
+                }
+                map.end()
+            }
+        }
+    }
+}
+
+impl<'de: 'a, 'a> Deserialize<'de> for Value<'a> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(ValueVisitor(PhantomData))
+    }
+}
+
+struct ValueVisitor<'a>(PhantomData<&'a ()>);
+
+impl<'de: 'a, 'a> Visitor<'de> for ValueVisitor<'a> {
+    type Value = Value<'a>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("any valid JSON value")
+    }
+
+    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
+        Ok(Value::Bool(value))
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
+        Ok(Value::Number(value.into()))
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(Value::Number(value.into()))
+    }
+
+    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Number::from_f64(value).map(Value::Number).ok_or_else(|| E::custom("not a JSON number"))
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
+        Ok(Value::String(Cow::Owned(value.to_owned())))
+    }
+
+    fn visit_borrowed_str<E>(self, value: &'de str) -> Result<Self::Value, E> {
+        Ok(Value::String(Cow::Borrowed(value)))
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+        Ok(Value::String(Cow::Owned(value)))
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E> {
+        Ok(Value::Null)
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(Value::Null)
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut values = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+        while let Some(value) = seq.next_element()? {
+            values.push(value);
+        }
+        Ok(Value::Array(values))
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut entries: Object<'a> = Vec::with_capacity(map.size_hint().unwrap_or(0));
+        let mut key_fingerprints = 0_u128;
+
+        while let Some(Key(key)) = map.next_key::<Key<'a>>()? {
+            let value = map.next_value()?;
+
+            // JSON permits duplicate keys. Match `serde_json::Map` by retaining the
+            // first position and replacing its value. The fingerprint is only a
+            // fast rejection filter; collisions fall back to an exact comparison.
+            let fingerprint =
+                key.bytes().fold(0_u8, |hash, byte| hash.wrapping_mul(31).wrapping_add(byte)) & 127;
+            let mask = 1_u128 << fingerprint;
+            if key_fingerprints & mask != 0 {
+                if let Some((_, previous)) =
+                    entries.iter_mut().find(|(previous, _)| previous == &key)
+                {
+                    *previous = value;
+                    continue;
+                }
+            }
+            key_fingerprints |= mask;
+            entries.push((key, value));
+        }
+
+        Ok(Value::Object(entries))
+    }
+}
+
+struct Key<'a>(Cow<'a, str>);
+
+impl<'de: 'a, 'a> Deserialize<'de> for Key<'a> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(KeyVisitor(PhantomData))
+    }
+}
+
+struct KeyVisitor<'a>(PhantomData<&'a ()>);
+
+impl<'de: 'a, 'a> Visitor<'de> for KeyVisitor<'a> {
+    type Value = Key<'a>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a string key")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
+        Ok(Key(Cow::Owned(value.to_owned())))
+    }
+
+    fn visit_borrowed_str<E>(self, value: &'de str) -> Result<Self::Value, E> {
+        Ok(Key(Cow::Borrowed(value)))
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+        Ok(Key(Cow::Owned(value)))
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -96,3 +96,31 @@ fn test_utf8_bom_preservation() {
     let second_sort = sort(&result);
     assert_eq!(result, second_sort, "Sorting BOM files should be idempotent");
 }
+
+#[test]
+fn test_json_representation_edge_cases() {
+    let input = r#"{
+  "version": "first",
+  "description": "line\n\u0061",
+  "name": "pkg",
+  "version": "last",
+  "nested": { "duplicate": 1, "duplicate": 2 },
+  "number": 1e+01
+}"#;
+
+    let pretty =
+        sort_package_json_with_options(input, &SortOptions { pretty: true, sort_scripts: false })
+            .unwrap();
+    assert_eq!(
+        pretty,
+        "{\n  \"name\": \"pkg\",\n  \"version\": \"last\",\n  \"description\": \"line\\na\",\n  \"nested\": {\n    \"duplicate\": 2\n  },\n  \"number\": 10.0\n}\n"
+    );
+
+    let compact =
+        sort_package_json_with_options(input, &SortOptions { pretty: false, sort_scripts: false })
+            .unwrap();
+    assert_eq!(
+        compact,
+        r#"{"name":"pkg","version":"last","description":"line\na","nested":{"duplicate":2},"number":10.0}"#
+    );
+}


### PR DESCRIPTION
Use a borrowing Serde value representation to avoid allocating JSON keys and strings while sorting. This removes `preserve_order`/IndexMap and improves the existing benchmarks by 2.08–2.48× while preserving serialized output.

Validated with the full `just` suite and byte-for-byte parity over 10,000 generated manifests.