### PR TITLE
feat!: prepare for 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,16 +2,15 @@
 name = "sort-package-json"
 version = "0.0.15"
 authors = ["Boshen <boshenc@gmail.com>"]
-categories = []
+categories = ["development-tools"]
 edition = "2021"
-include = ["/src"]
-keywords = []
+include = ["/src", "/benches", "/examples", "/tests", "/CHANGELOG.md", "/LICENSE", "/README.md"]
+keywords = ["formatter", "json", "npm", "package-json", "sort"]
 license = "MIT"
-publish = true
 readme = "README.md"
 repository = "https://github.com/oxc-project/sort-package-json"
 rust-version = "1.76"
-description = "A Rust implementation of sort-package-json that sorts package.json files according to well-established npm conventions"
+description = "Sort package.json files according to established npm conventions"
 
 [lints.rust]
 absolute_paths_not_starting_with_crate = "warn"
@@ -55,10 +54,6 @@ criterion2 = { version = "3", default-features = false }
 ignore = "0.4"
 insta = "1.41"
 
-[lib]
-test = false
-doctest = false
-
 [[bench]]
 name = "sort"
 harness = false
@@ -74,7 +69,7 @@ lto = "fat"
 codegen-units = 1
 strip = "symbols" # set to `false` for debug information
 debug = false # set to `true` for debug information
-panic = "abort" # Let it crash and force ourselves to write safe Rust.
+panic = "abort" # Abort instead of unwinding in release builds.
 
 [profile.dev]
 debug = "line-tables-only"

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ A Rust implementation that sorts package.json files according to well-establishe
 
 ## Features
 
-- **Sorts top-level fields** according to npm ecosystem conventions (138 predefined fields)
-- **Preserves all data** - only reorders fields, never modifies values
+- **Sorts top-level fields** according to npm ecosystem conventions (140 predefined fields)
+- **Normalizes string lists** where the ecosystem convention is to sort and remove duplicates
 - **Respects semantics** - `exports` and `imports` fields preserve their key order (first-match resolution)
-- **Fast and safe** - pure Rust implementation with no unsafe code
+- **Fast and memory-efficient** - borrows unescaped strings and minimizes output allocations
 - **Idempotent** - sorting multiple times produces the same result
 - **Handles edge cases** - unknown fields sorted alphabetically, private fields (starting with `_`) sorted last
 
@@ -32,7 +32,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-sort-package-json = "0.0.5"
+sort-package-json = "1"
 ```
 
 ### Library API
@@ -53,8 +53,9 @@ With custom options:
 ```rust
 use sort_package_json::{sort_package_json_with_options, SortOptions};
 
-let options = SortOptions { pretty: false };
-let sorted = sort_package_json_with_options(&contents, &options)?;
+let contents = r#"{"scripts":{"test":"vitest","build":"tsup"}}"#;
+let options = SortOptions::new().with_pretty(false).with_sort_scripts(true);
+let sorted = sort_package_json_with_options(contents, &options).expect("valid package.json");
 ```
 
 ### Running the Example
@@ -93,7 +94,7 @@ After sorting:
 
 ## Field Ordering
 
-Fields are sorted into 12 logical groups, followed by unknown fields alphabetically, then private fields (starting with `_`) at the end. The complete field order is based on both the [original sort-package-json](https://github.com/keithamus/sort-package-json/blob/main/index.js) and [prettier's package.json sorting](https://github.com/un-ts/prettier/blob/master/packages/pkg/src/rules/sort.ts) implementations.
+Fields are sorted into 12 logical groups, followed by unknown fields alphabetically, then private fields (starting with `_`) at the end. The abbreviated example below shows the groups and common fields. The ordering is based on both the [original sort-package-json](https://github.com/keithamus/sort-package-json/blob/main/index.js) and [Prettier's package.json sorting](https://github.com/un-ts/prettier/blob/master/packages/pkg/src/rules/sort.ts) implementations.
 
 ```jsonc
 {
@@ -222,11 +223,6 @@ Or to accept all changes:
 ```bash
 cargo insta accept
 ```
-
-### Test Coverage
-
-- **Field ordering test** - verifies correct sorting of all field types
-- **Idempotency test** - ensures sorting is stable (sorting twice = sorting once)
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,15 @@
+//! Sort `package.json` fields according to established npm conventions.
+//!
+//! The default API returns pretty-printed JSON with a trailing newline:
+//!
+//! ```
+//! let input = r#"{"version":"1.0.0","name":"example"}"#;
+//! let sorted = sort_package_json::sort_package_json(input)?;
+//!
+//! assert_eq!(sorted, "{\n  \"name\": \"example\",\n  \"version\": \"1.0.0\"\n}\n");
+//! # Ok::<(), serde_json::Error>(())
+//! ```
+
 mod value;
 
 use std::borrow::Cow;
@@ -8,7 +20,8 @@ use value::{Object, Value};
 const BOM_STR: &str = "\u{FEFF}";
 
 /// Options for controlling JSON formatting when sorting.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct SortOptions {
     /// Whether to pretty-print the output JSON.
     pub pretty: bool,
@@ -16,13 +29,42 @@ pub struct SortOptions {
     pub sort_scripts: bool,
 }
 
-impl Default for SortOptions {
-    fn default() -> Self {
+impl SortOptions {
+    /// Creates options with the default behavior.
+    #[must_use]
+    pub const fn new() -> Self {
         Self { pretty: true, sort_scripts: false }
+    }
+
+    /// Sets whether the output is pretty-printed.
+    #[must_use]
+    pub const fn with_pretty(mut self, pretty: bool) -> Self {
+        self.pretty = pretty;
+        self
+    }
+
+    /// Sets whether the `scripts`, `betterScripts`, and `wireit` fields are sorted.
+    #[must_use]
+    pub const fn with_sort_scripts(mut self, sort_scripts: bool) -> Self {
+        self.sort_scripts = sort_scripts;
+        self
     }
 }
 
-/// Sorts a `package.json` string with custom options.
+impl Default for SortOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Sorts a `package.json` string using custom [`SortOptions`].
+///
+/// A UTF-8 byte order mark in `input` is preserved. Pretty-printed output ends in a newline;
+/// compact output does not.
+///
+/// # Errors
+///
+/// Returns an error when `input` is not valid JSON.
 pub fn sort_package_json_with_options(
     input: &str,
     options: &SortOptions,
@@ -61,7 +103,13 @@ pub fn sort_package_json_with_options(
     Ok(unsafe { String::from_utf8_unchecked(buf) })
 }
 
-/// Sorts a `package.json` string with default options (pretty-printed).
+/// Sorts a `package.json` string with the default options.
+///
+/// The output is pretty-printed with a trailing newline. Script order is preserved.
+///
+/// # Errors
+///
+/// Returns an error when `input` is not valid JSON.
 pub fn sort_package_json(input: &str) -> Result<String, serde_json::Error> {
     sort_package_json_with_options(input, &SortOptions::default())
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,8 +3,8 @@ use sort_package_json::{SortOptions, sort_package_json_with_options};
 use std::fs;
 
 fn sort(s: &str) -> String {
-    sort_package_json_with_options(s, &SortOptions { pretty: true, sort_scripts: true })
-        .expect("Failed to parse package.json")
+    let options = SortOptions::new().with_sort_scripts(true);
+    sort_package_json_with_options(s, &options).expect("Failed to parse package.json")
 }
 
 #[test]
@@ -108,17 +108,14 @@ fn test_json_representation_edge_cases() {
   "number": 1e+01
 }"#;
 
-    let pretty =
-        sort_package_json_with_options(input, &SortOptions { pretty: true, sort_scripts: false })
-            .unwrap();
+    let pretty = sort_package_json_with_options(input, &SortOptions::new()).unwrap();
     assert_eq!(
         pretty,
         "{\n  \"name\": \"pkg\",\n  \"version\": \"last\",\n  \"description\": \"line\\na\",\n  \"nested\": {\n    \"duplicate\": 2\n  },\n  \"number\": 10.0\n}\n"
     );
 
     let compact =
-        sort_package_json_with_options(input, &SortOptions { pretty: false, sort_scripts: false })
-            .unwrap();
+        sort_package_json_with_options(input, &SortOptions::new().with_pretty(false)).unwrap();
     assert_eq!(
         compact,
         r#"{"name":"pkg","version":"last","description":"line\na","nested":{"duplicate":2},"number":10.0}"#


### PR DESCRIPTION
Stabilizes the public `SortOptions` API and refreshes published crate metadata and documentation ahead of 1.0.0.

Validation: `cargo test --locked`; `cargo clippy --workspace --all-targets --all-features --locked -- --deny warnings`.