### PR TITLE
chore: release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0](https://github.com/oxc-project/sort-package-json/compare/v0.0.15...v1.0.0) - 2026-08-16
+
+### Changed
+
+- **Breaking:** Stabilize the public `SortOptions` API and refresh crate metadata and documentation ([#158](https://github.com/oxc-project/sort-package-json/pull/158))
+
 ## [0.0.15](https://github.com/oxc-project/sort-package-json/compare/v0.0.14...v0.0.15) - 2026-08-16
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "sort-package-json"
-version = "0.0.15"
+version = "1.0.0"
 dependencies = [
  "criterion2",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sort-package-json"
-version = "0.0.15"
+version = "1.0.0"
 authors = ["Boshen <boshenc@gmail.com>"]
 categories = ["development-tools"]
 edition = "2021"


### PR DESCRIPTION
Bumps the crate and lockfile to `1.0.0` and records the release in the changelog.

Validation: `cargo package --locked`; `cargo test --locked`; Clippy and rustdoc.