### PR TITLE
feat: sort scripts with lifecycle grouping and colon namespaces

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,6 +223,198 @@ fn sort_people_object(obj: Object<'_>) -> Object<'_> {
     sort_object_by_key_order(obj, &["name", "email", "url"])
 }
 
+// ===== Scripts sorting with lifecycle grouping ==============================
+
+/// npm lifecycle scripts whose `pre` / `post` prefixes are always recognized,
+/// even when the base name itself is not explicitly present in the `scripts`
+/// object. See <https://docs.npmjs.com/cli/v10/using-npm/scripts>.
+const DEFAULT_NPM_SCRIPTS: &[&str] = &[
+    "install",
+    "pack",
+    "prepare",
+    "publish",
+    "restart",
+    "shrinkwrap",
+    "start",
+    "stop",
+    "test",
+    "uninstall",
+    "version",
+];
+
+/// Recursively sort script names by colon-delimited namespace.
+///
+/// 1. All names are partitioned into groups. The group key for a name is the
+///    text before the **first** colon after `prefix`. Names that have no colon
+///    (i.e. are exactly the group key) are "direct" members.
+/// 2. Groups are sorted alphabetically by group key.
+/// 3. Within each group the direct member (if any) comes first, followed by
+///    the colon-children **recursively sorted** using the group key as the new
+///    prefix.
+///
+/// This mirrors the JS `sortScriptNames` in `sort-package-json`.
+fn sort_script_names(names: &[&str], prefix: &str) -> Vec<String> {
+    // Collect groups: group_key → list of full names.
+    let mut groups: Vec<(&str, Vec<&str>)> = Vec::new();
+    let mut group_index = std::collections::HashMap::<&str, usize>::new();
+
+    for &name in names {
+        // Portion of the name after the prefix (+ separator colon).
+        let rest = if prefix.is_empty() { name } else { &name[prefix.len() + 1..] };
+        let colon_idx = rest.find(':');
+        let group_key = match colon_idx {
+            // Has a colon after at least one character → group key is the part before it.
+            // If the colon is at position 0 (name starts with `:` or `prefix::`) the
+            // name is treated as having no sub-namespace — same as `None`.
+            Some(idx) if idx > 0 => {
+                let base_len = if prefix.is_empty() { idx } else { prefix.len() + 1 + idx };
+                &name[..base_len]
+            }
+            // No colon, or colon at position 0 → the name itself is the group key.
+            _ => name,
+        };
+
+        if let Some(&gi) = group_index.get(group_key) {
+            groups[gi].1.push(name);
+        } else {
+            group_index.insert(group_key, groups.len());
+            groups.push((group_key, vec![name]));
+        }
+    }
+
+    // Sort groups by group key.
+    groups.sort_by_key(|(a, _)| *a);
+
+    let mut result = Vec::with_capacity(names.len());
+    for (group_key, children) in groups {
+        if children.len() > 1
+            && children.iter().any(|k| *k != group_key && k.starts_with(group_key))
+        {
+            // Separate direct members from colon-children.
+            let mut direct: Vec<&str> = children
+                .iter()
+                .filter(|k| **k == group_key || !k.starts_with(&format!("{group_key}:")))
+                .copied()
+                .collect();
+            direct.sort();
+
+            let nested: Vec<&str> = children
+                .iter()
+                .filter(|k| k.starts_with(&format!("{group_key}:")))
+                .copied()
+                .collect();
+
+            result.extend(direct.into_iter().map(String::from));
+            result.extend(sort_script_names(&nested, group_key));
+        } else {
+            let mut sorted: Vec<&str> = children;
+            sorted.sort();
+            result.extend(sorted.into_iter().map(String::from));
+        }
+    }
+    result
+}
+
+/// Sorts a `scripts` (or `betterScripts`) object with colon-namespace grouping
+/// and lifecycle (`pre` / `post`) script collocation.
+///
+/// The algorithm (matching the npm `sort-package-json` package):
+///
+/// 1. **Deduplicate prefixable names** — for every name starting with `pre` or
+///    `post`, check whether the remainder is either a default npm lifecycle
+///    script **or** an explicit script in the object. If so, record the base
+///    name as *prefixable* and replace the original with its base name in the
+///    sort input.
+/// 2. **Sort by colon namespace** — call [`sort_script_names`].
+/// 3. **Expand prefixable names** — each prefixable base name is expanded to
+///    `[pre<name>, <name>, post<name>]`.
+/// 4. **Reorder the object** according to the computed name list. Scripts whose
+///    names do not appear in the list (e.g. orphan `pre` / `post` scripts after
+///    expansion that have no corresponding entry in the original object) are
+///    silently omitted, and scripts present in the original but absent from the
+///    list are appended in their original order.
+fn sort_scripts_object(obj: Object<'_>) -> Object<'_> {
+    let keys: Vec<&str> = obj.iter().map(|(k, _)| k.as_ref()).collect();
+    let key_set: std::collections::HashSet<&str> = keys.iter().copied().collect();
+
+    // Step 1: Determine which base names are prefixable.
+    let mut prefixable = std::collections::HashSet::new();
+    let mut deduped_names: Vec<&str> = Vec::with_capacity(keys.len());
+
+    for &name in &keys {
+        if let Some(base) = name.strip_prefix("pre") {
+            if !base.is_empty()
+                && (DEFAULT_NPM_SCRIPTS.contains(&base) || key_set.contains(base))
+            {
+                prefixable.insert(base);
+                if !deduped_names.contains(&base) {
+                    deduped_names.push(base);
+                }
+                continue;
+            }
+        }
+        if let Some(base) = name.strip_prefix("post") {
+            if !base.is_empty()
+                && (DEFAULT_NPM_SCRIPTS.contains(&base) || key_set.contains(base))
+            {
+                prefixable.insert(base);
+                if !deduped_names.contains(&base) {
+                    deduped_names.push(base);
+                }
+                continue;
+            }
+        }
+        if !deduped_names.contains(&name) {
+            deduped_names.push(name);
+        }
+    }
+
+    // Step 2: Sort by colon namespace.
+    let sorted_names = sort_script_names(&deduped_names, "");
+
+    // Step 3: Expand prefixable names.
+    let mut ordered_names: Vec<String> = Vec::with_capacity(keys.len());
+    for name in &sorted_names {
+        if prefixable.contains(name.as_str()) {
+            let pre = format!("pre{name}");
+            let post = format!("post{name}");
+            ordered_names.push(pre);
+            ordered_names.push(name.clone());
+            ordered_names.push(post);
+        } else {
+            ordered_names.push(name.clone());
+        }
+    }
+
+    // Step 4: Reorder object entries.
+    // Build a position map for O(1) lookup.
+    let position: std::collections::HashMap<&str, usize> = ordered_names
+        .iter()
+        .enumerate()
+        .map(|(i, name)| (name.as_str(), i))
+        .collect();
+
+    let mut entries: Vec<(usize, Cow<'_, str>, Value<'_>)> = Vec::with_capacity(obj.len());
+    let mut unordered: Object<'_> = Vec::new();
+
+    for (key, value) in obj {
+        match position.get(key.as_ref()) {
+            Some(&pos) => entries.push((pos, key, value)),
+            // Original key not in expansion list → append at end.
+            None => unordered.push((key, value)),
+        }
+    }
+
+    entries.sort_by_key(|(pos, _, _)| *pos);
+
+    let mut result = Vec::with_capacity(entries.len() + unordered.len());
+    for (_, key, value) in entries {
+        result.push((key, value));
+    }
+    result.extend(unordered);
+    result
+}
+
 fn sort_dev_engine(value: Value<'_>) -> Value<'_> {
     const KEY_ORDER: &[&str] = &["name", "version", "onFail"];
 
@@ -347,8 +539,8 @@ fn sort_object_keys<'a>(obj: Object<'a>, options: &SortOptions) -> Object<'a> {
             64 => "exports",
             65 => "publishConfig" => transform_value(value, |o| sort_object_keys(o, options)),
             // Scripts
-            66 => "scripts" => if options.sort_scripts { transform_value(value, sort_object_alphabetically) } else { value },
-            67 => "betterScripts" => if options.sort_scripts { transform_value(value, sort_object_alphabetically) } else { value },
+            66 => "scripts" => if options.sort_scripts { transform_value(value, sort_scripts_object) } else { value },
+            67 => "betterScripts" => if options.sort_scripts { transform_value(value, sort_scripts_object) } else { value },
             68 => "wireit" => if options.sort_scripts { transform_value(value, sort_object_alphabetically) } else { value },
             // Dependencies
             69 => "dependencies" => transform_value(value, sort_object_alphabetically),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7,6 +7,98 @@ fn sort(s: &str) -> String {
     sort_package_json_with_options(s, &options).expect("Failed to parse package.json")
 }
 
+/// Extract the immediate keys of the first `{ ... }` object value for a given
+/// `"key":` in the JSON text, preserving serialization order.
+///
+/// We cannot use `serde_json::Value` for this because its default `Map` is a
+/// `BTreeMap` that loses insertion order.
+fn get_script_keys(json: &str, field: &str) -> Vec<String> {
+    let needle = format!("\"{field}\":");
+    let start = match json.find(&needle) {
+        Some(pos) => pos + needle.len(),
+        None => return Vec::new(),
+    };
+    let brace_rel = match json[start..].find('{') {
+        Some(pos) => pos,
+        None => return Vec::new(),
+    };
+    let obj_start = start + brace_rel;
+
+    // Walk the object text, tracking brace/bracket/string state,
+    // and collect keys at depth == 1.
+    let mut keys = Vec::new();
+    let mut depth = 0i32;
+    let mut in_string = false;
+    let mut prev_backslash = false;
+    let bytes = json.as_bytes();
+    let mut i = obj_start;
+    while i < bytes.len() {
+        let ch = bytes[i] as char;
+        if in_string {
+            if ch == '\\' && !prev_backslash {
+                prev_backslash = true;
+                i += 1;
+                continue;
+            }
+            if ch == '"' && !prev_backslash {
+                in_string = false;
+            }
+            prev_backslash = false;
+            i += 1;
+            continue;
+        }
+        match ch {
+            '{' | '[' => {
+                depth += 1;
+                i += 1;
+            }
+            '}' | ']' => {
+                depth -= 1;
+                if depth == 0 {
+                    break;
+                }
+                i += 1;
+            }
+            '"' if depth == 1 => {
+                // Possibly a key. Find the closing quote.
+                let s = i + 1;
+                let mut e = s;
+                let mut esc = false;
+                while e < bytes.len() {
+                    if esc {
+                        esc = false;
+                        e += 1;
+                        continue;
+                    }
+                    if bytes[e] == b'\\' {
+                        esc = true;
+                        e += 1;
+                        continue;
+                    }
+                    if bytes[e] == b'"' {
+                        break;
+                    }
+                    e += 1;
+                }
+                let candidate = &json[s..e];
+                let after = &json[e + 1..].trim_start();
+                if after.starts_with(':') {
+                    keys.push(candidate.to_string());
+                }
+                i = e + 1;
+            }
+            '"' => {
+                in_string = true;
+                i += 1;
+            }
+            _ => {
+                i += 1;
+            }
+        }
+    }
+    keys
+}
+
 #[test]
 fn test_sort_package_json() {
     let input = fs::read_to_string("tests/fixtures/package.json").expect("Failed to read fixture");
@@ -120,4 +212,490 @@ fn test_json_representation_edge_cases() {
         compact,
         r#"{"name":"pkg","version":"last","description":"line\na","nested":{"duplicate":2},"number":10.0}"#
     );
+}
+
+// ===== Scripts lifecycle sorting =============================================
+//
+// Tests adapted from the npm `sort-package-json` test suite
+// (keithamus/sort-package-json, tests/scripts.js) and extended with additional
+// edge cases.
+
+/// Ported from npm sort-package-json: the main fixture with pre/post lifecycle
+/// scripts, custom scripts, and a hyphenated name that looks like "pre-*".
+#[test]
+fn scripts_lifecycle_main_fixture() {
+    let input = r#"{
+  "scripts": {
+    "test": "node test.js",
+    "multiply": "2 * 3",
+    "watch": "watch things",
+    "prewatch": "echo about to watch",
+    "postinstall": "echo Installed",
+    "preinstall": "echo Installing",
+    "start": "node server.js",
+    "posttest": "abc",
+    "pretest": "xyz",
+    "postprettier": "echo so pretty",
+    "preprettier": "echo not pretty",
+    "prettier": "prettier -l **/*.js",
+    "prepare": "npm run build",
+    "pre-fetch-info": "foo"
+  }
+}"#;
+    let result = sort(input);
+    let keys = get_script_keys(&result, "scripts");
+    assert_eq!(
+        keys,
+        vec![
+            "preinstall",
+            "postinstall",
+            "multiply",
+            "pre-fetch-info",
+            "prepare",
+            "preprettier",
+            "prettier",
+            "postprettier",
+            "start",
+            "pretest",
+            "test",
+            "posttest",
+            "prewatch",
+            "watch",
+        ]
+    );
+}
+
+/// Ported from npm: pre/post scripts with colons should NOT be grouped with
+/// their base lifecycle. `prebuild:1` is a colon-variant of `prebuild`, not a
+/// pre-script for `build:1`.
+#[test]
+fn scripts_does_not_sort_pre_post_colon_together() {
+    let input = r#"{
+  "scripts": {
+    "prebuild": "run-s prebuild:*",
+    "prebuild:1": "node prebuild.js 1",
+    "prebuild:2": "node prebuild.js 2",
+    "prebuild:3": "node prebuild.js 3",
+    "build": "run-s build:*",
+    "build:bar": "node bar.js",
+    "build:baz": "node baz.js",
+    "build:foo": "node foo.js",
+    "postbuild": "run-s prebuild:*",
+    "postbuild:1": "node prebuild.js 1",
+    "postbuild:2": "node prebuild.js 2",
+    "postbuild:3": "node prebuild.js 3",
+    "d-unrelated": "..",
+    "e-unrelated": "..",
+    "f-unrelated": ".."
+  }
+}"#;
+    let result = sort(input);
+    let keys = get_script_keys(&result, "scripts");
+    assert_eq!(
+        keys,
+        vec![
+            "prebuild",
+            "build",
+            "postbuild",
+            "build:bar",
+            "build:baz",
+            "build:foo",
+            "d-unrelated",
+            "e-unrelated",
+            "f-unrelated",
+            "postbuild:1",
+            "postbuild:2",
+            "postbuild:3",
+            "prebuild:1",
+            "prebuild:2",
+            "prebuild:3",
+        ]
+    );
+}
+
+/// Ported from npm: pre/post scripts for colon-namespaced scripts.
+/// `pretest:es-check` and `posttest:es-check` should surround `test:es-check`.
+#[test]
+fn scripts_pre_post_for_colon_scripts() {
+    let input = r#"{
+  "scripts": {
+    "pretest:es-check": "echo",
+    "posttest:es-check": "echo",
+    "test": "echo",
+    "test:coverage": "echo",
+    "test:es-check": "echo",
+    "test:types": "echo"
+  }
+}"#;
+    let result = sort(input);
+    let keys = get_script_keys(&result, "scripts");
+    assert_eq!(
+        keys,
+        vec![
+            "test",
+            "test:coverage",
+            "pretest:es-check",
+            "test:es-check",
+            "posttest:es-check",
+            "test:types",
+        ]
+    );
+}
+
+/// Ported from npm: base and colon scripts grouped together, not split by
+/// unrelated scripts that happen to sort between them.
+#[test]
+fn scripts_group_base_and_colon_together() {
+    let input = r#"{
+  "scripts": {
+    "test": "run-s test:a test:b",
+    "test:a": "foo",
+    "test:b": "bar",
+    "test-coverage": "c8 node --run test"
+  }
+}"#;
+    let result = sort(input);
+    let keys = get_script_keys(&result, "scripts");
+    assert_eq!(keys, vec!["test", "test:a", "test:b", "test-coverage"]);
+}
+
+/// Ported from npm: scripts with multiple colons are recursively grouped.
+#[test]
+fn scripts_multiple_colons() {
+    let input = r#"{
+  "scripts": {
+    "test": "run-s test:a test:b",
+    "test:a": "foo",
+    "test:b": "bar",
+    "pretest:a": "foo",
+    "posttest:a": "foo",
+    "pretest:a:a": "foo",
+    "posttest:a:a": "foo",
+    "test:a:a": "foofoo",
+    "test:a:b": "foobar",
+    "pretest:ab": "foobar",
+    "test:ab": "foobar",
+    "test:a-coverage": "foobar",
+    "test:b:a": "barfoo",
+    "test:b:b": "barbar",
+    "test-coverage": "c8 node --run test"
+  }
+}"#;
+    let result = sort(input);
+    let keys = get_script_keys(&result, "scripts");
+    assert_eq!(
+        keys,
+        vec![
+            "test",
+            "pretest:a",
+            "test:a",
+            "posttest:a",
+            "pretest:a:a",
+            "test:a:a",
+            "posttest:a:a",
+            "test:a:b",
+            "test:a-coverage",
+            "pretest:ab",
+            "test:ab",
+            "test:b",
+            "test:b:a",
+            "test:b:b",
+            "test-coverage",
+        ]
+    );
+}
+
+/// Ported from npm: handles names starting with colon and double colons.
+#[test]
+fn scripts_colon_prefix_and_double_colons() {
+    let input = r#"{
+  "scripts": {
+    "::delta": "echo",
+    "test": "echo",
+    ":beta": "echo",
+    ":alpha:sub": "echo",
+    ":alpha": "echo",
+    "test::coverage": "echo",
+    ":alpha::extra": "echo",
+    "test:lint": "echo",
+    "test::smoke": "echo"
+  }
+}"#;
+    let result = sort(input);
+    let keys = get_script_keys(&result, "scripts");
+    assert_eq!(
+        keys,
+        vec![
+            "::delta",
+            ":alpha",
+            ":alpha::extra",
+            ":alpha:sub",
+            ":beta",
+            "test",
+            "test::coverage",
+            "test::smoke",
+            "test:lint",
+        ]
+    );
+}
+
+/// Ported from npm: nested production and format variants grouped and sorted.
+#[test]
+fn scripts_nested_production_variants() {
+    let input = r#"{
+  "scripts": {
+    "test": "echo",
+    "test:a": "echo",
+    "test:b": "echo",
+    "test:ab": "echo",
+    "test-coverage": "echo",
+    "test:production": "echo",
+    "test:production:a": "echo",
+    "test:production:b": "echo",
+    "test:production-coverage": "echo",
+    "test:production2": "echo",
+    "test:production$2": "echo",
+    "test:production:cjs": "echo",
+    "test:production:cjs:a": "echo",
+    "test:production:cjs:b": "echo",
+    "test:production:cjs-coverage": "echo",
+    "test:production:mjs": "echo",
+    "test:production:mjs:a": "echo",
+    "test:production:mjs:b": "echo",
+    "test:production:mjs-coverage": "echo"
+  }
+}"#;
+    let result = sort(input);
+    let keys = get_script_keys(&result, "scripts");
+    assert_eq!(
+        keys,
+        vec![
+            "test",
+            "test:a",
+            "test:ab",
+            "test:b",
+            "test:production",
+            "test:production:a",
+            "test:production:b",
+            "test:production:cjs",
+            "test:production:cjs:a",
+            "test:production:cjs:b",
+            "test:production:cjs-coverage",
+            "test:production:mjs",
+            "test:production:mjs:a",
+            "test:production:mjs:b",
+            "test:production:mjs-coverage",
+            "test:production$2",
+            "test:production-coverage",
+            "test:production2",
+            "test-coverage",
+        ]
+    );
+}
+
+// -- Additional edge cases ---------------------------------------------------
+
+/// `preinstall` and `postinstall` recognized even without explicit `install` script.
+#[test]
+fn scripts_lifecycle_without_base_script() {
+    let input = r#"{
+  "scripts": {
+    "postinstall": "echo done",
+    "preinstall": "echo start",
+    "build": "tsc"
+  }
+}"#;
+    let result = sort(input);
+    let keys = get_script_keys(&result, "scripts");
+    assert_eq!(keys, vec!["build", "preinstall", "postinstall"]);
+}
+
+/// Only `pre` without matching `post` (or vice versa).
+#[test]
+fn scripts_pre_only() {
+    let input = r#"{
+  "scripts": {
+    "pretest": "lint",
+    "test": "jest"
+  }
+}"#;
+    let result = sort(input);
+    let keys = get_script_keys(&result, "scripts");
+    assert_eq!(keys, vec!["pretest", "test"]);
+}
+
+#[test]
+fn scripts_post_only() {
+    let input = r#"{
+  "scripts": {
+    "posttest": "coverage",
+    "test": "jest"
+  }
+}"#;
+    let result = sort(input);
+    let keys = get_script_keys(&result, "scripts");
+    assert_eq!(keys, vec!["test", "posttest"]);
+}
+
+/// `pre-*` with a hyphen is NOT a lifecycle prefix — it is an ordinary script.
+#[test]
+fn scripts_hyphenated_pre_not_lifecycle() {
+    let input = r#"{
+  "scripts": {
+    "pre-deploy": "build",
+    "deploy": "push",
+    "predeploy": "lint"
+  }
+}"#;
+    let result = sort(input);
+    let keys = get_script_keys(&result, "scripts");
+    // "predeploy" IS a lifecycle prefix for "deploy"; "pre-deploy" is just alphabetical.
+    assert_eq!(keys, vec!["predeploy", "deploy", "pre-deploy"]);
+}
+
+/// Empty scripts object.
+#[test]
+fn scripts_empty() {
+    let input = r#"{ "scripts": {} }"#;
+    let result = sort(input);
+    let keys = get_script_keys(&result, "scripts");
+    assert!(keys.is_empty());
+}
+
+/// Single script.
+#[test]
+fn scripts_single() {
+    let input = r#"{ "scripts": { "build": "tsc" } }"#;
+    let result = sort(input);
+    let keys = get_script_keys(&result, "scripts");
+    assert_eq!(keys, vec!["build"]);
+}
+
+/// Pure alphabetical when no pre/post or colons.
+#[test]
+fn scripts_plain_alphabetical() {
+    let input = r#"{
+  "scripts": {
+    "z": "z",
+    "a": "a",
+    "m": "m"
+  }
+}"#;
+    let result = sort(input);
+    let keys = get_script_keys(&result, "scripts");
+    assert_eq!(keys, vec!["a", "m", "z"]);
+}
+
+/// `betterScripts` field gets the same treatment.
+#[test]
+fn better_scripts_same_sorting() {
+    let input = r#"{
+  "betterScripts": {
+    "posttest": "coverage",
+    "test": "jest",
+    "pretest": "lint",
+    "build": "tsc"
+  }
+}"#;
+    let result = sort(input);
+    let keys = get_script_keys(&result, "betterScripts");
+    assert_eq!(keys, vec!["build", "pretest", "test", "posttest"]);
+}
+
+/// When `sort_scripts` is false, order is preserved.
+#[test]
+fn scripts_sort_disabled() {
+    let input = r#"{
+  "scripts": {
+    "posttest": "coverage",
+    "test": "jest",
+    "pretest": "lint",
+    "build": "tsc"
+  }
+}"#;
+    let options = SortOptions::new().with_sort_scripts(false);
+    let result = sort_package_json_with_options(input, &options).unwrap();
+    let keys = get_script_keys(&result, "scripts");
+    assert_eq!(keys, vec!["posttest", "test", "pretest", "build"]);
+}
+
+/// Scripts sorting is idempotent.
+#[test]
+fn scripts_idempotent() {
+    let input = r#"{
+  "scripts": {
+    "test": "node test.js",
+    "posttest": "abc",
+    "pretest": "xyz",
+    "build": "tsc",
+    "build:watch": "tsc -w",
+    "prebuild": "clean"
+  }
+}"#;
+    let first = sort(input);
+    let second = sort(&first);
+    assert_eq!(first, second, "Scripts sorting should be idempotent");
+}
+
+/// Orphan `pre`/`post` scripts (no matching base or lifecycle) treated as regular.
+#[test]
+fn scripts_orphan_pre_post() {
+    let input = r#"{
+  "scripts": {
+    "prefoo": "echo pre",
+    "postbar": "echo post",
+    "build": "tsc"
+  }
+}"#;
+    let result = sort(input);
+    let keys = get_script_keys(&result, "scripts");
+    // No "foo" or "bar" script exists and they are not default npm lifecycle names,
+    // so "prefoo" and "postbar" are treated as ordinary scripts sorted alphabetically.
+    assert_eq!(keys, vec!["build", "postbar", "prefoo"]);
+}
+
+/// All default npm lifecycle scripts recognized without explicit base.
+#[test]
+fn scripts_all_default_lifecycle_scripts() {
+    let input = r#"{
+  "scripts": {
+    "postversion": "push",
+    "preversion": "lint",
+    "poststop": "log",
+    "prestop": "warn",
+    "poststart": "notify",
+    "prestart": "check"
+  }
+}"#;
+    let result = sort(input);
+    let keys = get_script_keys(&result, "scripts");
+    assert_eq!(
+        keys,
+        vec![
+            "prestart",
+            "poststart",
+            "prestop",
+            "poststop",
+            "preversion",
+            "postversion",
+        ]
+    );
+}
+
+/// Scripts values are preserved (not just keys).
+#[test]
+fn scripts_values_preserved() {
+    let input = r#"{
+  "scripts": {
+    "posttest": "echo post",
+    "test": "jest --coverage",
+    "pretest": "echo pre"
+  }
+}"#;
+    let result = sort(input);
+    let parsed: Value = serde_json::from_str(&result).unwrap();
+    let scripts = parsed.get("scripts").unwrap();
+    assert_eq!(scripts.get("pretest").and_then(|v| v.as_str()), Some("echo pre"));
+    assert_eq!(scripts.get("test").and_then(|v| v.as_str()), Some("jest --coverage"));
+    assert_eq!(scripts.get("posttest").and_then(|v| v.as_str()), Some("echo post"));
 }

--- a/tests/snapshots/integration_test__sort_package_json.snap
+++ b/tests/snapshots/integration_test__sort_package_json.snap
@@ -118,9 +118,9 @@ expression: result
     "build": "webpack",
     "dev": "webpack serve",
     "lint": "eslint .",
-    "posttest": "echo 'Tests complete'",
     "pretest": "echo 'Starting tests'",
-    "test": "jest"
+    "test": "jest",
+    "posttest": "echo 'Tests complete'"
   },
   "dependencies": {
     "axios": "^1.0.0",


### PR DESCRIPTION
## Summary

Sort `scripts` and `betterScripts` fields with lifecycle-aware grouping, matching the behavior of the npm [`sort-package-json`](https://github.com/keithamus/sort-package-json) package.

### Sorting rules

**Colon-namespace grouping** — scripts sharing a colon-delimited prefix are grouped together. Groups are sorted alphabetically, and children are recursively sorted within their group:

```
test → test, test:a, test:b          (grouped)
test:production → test:production, test:production:cjs, test:production:mjs  (nested group)
test-coverage                         (separate, not colon-grouped)
```

**pre/post lifecycle collocation** — `pretest` is placed immediately before `test`, and `posttest` immediately after:

```jsonc
// Input                          // Output
"posttest": "coverage",           "pretest": "lint",
"test": "jest",         →         "test": "jest",
"pretest": "lint"                 "posttest": "coverage"
```

This applies to:
- All 11 default npm lifecycle scripts (`install`, `test`, `start`, `stop`, `publish`, `prepare`, etc.) — recognized **unconditionally**, even without the base script present
- User-defined scripts — recognized only when the base script also exists in the object
- **Not** hyphenated names: `pre-deploy` is an ordinary script, not a lifecycle prefix for `deploy`

### What is NOT included

- **`npm-run-all` detection** — the npm package skips script sorting when it detects sequential glob scripts (`run-s "lint:*"`). This requires cross-field access to `devDependencies` which would need an architecture change to the current per-field transform model. Intentionally deferred.
- **`wireit`** — kept as pure alphabetical sort (wireit has its own dependency-based execution model, not lifecycle-based).

### Test coverage

Added 20 new test cases adapted from the npm `sort-package-json` test suite (`tests/scripts.js`) and extended with additional edge cases:

| Test | Source |
|---|---|
| Main fixture (pre/post/custom/hyphenated) | npm port |
| pre/post with colons NOT grouped together | npm port |
| pre/post for colon-namespaced scripts | npm port |
| Base and colon scripts grouped, not split | npm port |
| Multiple colons (recursive grouping) | npm port |
| Colon-prefix and double-colon names | npm port |
| Nested production variants | npm port |
| Lifecycle without base script | custom |
| pre-only / post-only | custom |
| Hyphenated pre is not lifecycle | custom |
| Empty / single script | custom |
| Plain alphabetical (no lifecycle) | custom |
| betterScripts same treatment | custom |
| sort_scripts=false preserves order | custom |
| Idempotency | custom |
| Orphan pre/post (no matching base) | custom |
| All default npm lifecycle scripts | custom |
| Values preserved after reorder | custom |