### PR TITLE
feat: support custom indentation in SortOptions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,39 +14,54 @@ mod value;
 
 use std::borrow::Cow;
 
+use serde::Serialize;
+use serde_json::ser::{PrettyFormatter, Serializer};
 use value::{Object, Value};
 
 /// UTF-8 BOM (`U+FEFF`).
 const BOM_STR: &str = "\u{FEFF}";
 
 /// Options for controlling JSON formatting when sorting.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct SortOptions {
     /// Whether to pretty-print the output JSON.
     pub pretty: bool,
     /// Whether to sort the scripts field alphabetically.
     pub sort_scripts: bool,
+    /// Indentation string used when pretty-printing (e.g. `"  "`, `"\t"`, `"    "`).
+    ///
+    /// Defaults to two spaces. Only meaningful when [`pretty`](Self::pretty) is `true`.
+    pub indent: String,
 }
 
 impl SortOptions {
     /// Creates options with the default behavior.
     #[must_use]
-    pub const fn new() -> Self {
-        Self { pretty: true, sort_scripts: false }
+    pub fn new() -> Self {
+        Self { pretty: true, sort_scripts: false, indent: "  ".to_string() }
     }
 
     /// Sets whether the output is pretty-printed.
     #[must_use]
-    pub const fn with_pretty(mut self, pretty: bool) -> Self {
+    pub fn with_pretty(mut self, pretty: bool) -> Self {
         self.pretty = pretty;
         self
     }
 
     /// Sets whether the `scripts`, `betterScripts`, and `wireit` fields are sorted.
     #[must_use]
-    pub const fn with_sort_scripts(mut self, sort_scripts: bool) -> Self {
+    pub fn with_sort_scripts(mut self, sort_scripts: bool) -> Self {
         self.sort_scripts = sort_scripts;
+        self
+    }
+
+    /// Sets the indentation string used when pretty-printing.
+    ///
+    /// Common values: `"  "` (two spaces, the default), `"\t"` (tab), `"    "` (four spaces).
+    #[must_use]
+    pub fn with_indent<S: Into<String>>(mut self, indent: S) -> Self {
+        self.indent = indent.into();
         self
     }
 }
@@ -92,7 +107,9 @@ pub fn sort_package_json_with_options(
         buf.extend_from_slice(BOM_STR.as_bytes());
     }
     if options.pretty {
-        serde_json::to_writer_pretty(&mut buf, &sorted)?;
+        let formatter = PrettyFormatter::with_indent(options.indent.as_bytes());
+        let mut ser = Serializer::with_formatter(&mut buf, formatter);
+        sorted.serialize(&mut ser)?;
         buf.push(b'\n');
     } else {
         serde_json::to_writer(&mut buf, &sorted)?;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -121,3 +121,53 @@ fn test_json_representation_edge_cases() {
         r#"{"name":"pkg","version":"last","description":"line\na","nested":{"duplicate":2},"number":10.0}"#
     );
 }
+
+#[test]
+fn test_custom_indent_tab() {
+    let input = r#"{"version":"1.0.0","name":"example"}"#;
+    let result =
+        sort_package_json_with_options(input, &SortOptions::new().with_indent("\t")).unwrap();
+    assert_eq!(result, "{\n\t\"name\": \"example\",\n\t\"version\": \"1.0.0\"\n}\n");
+}
+
+#[test]
+fn test_custom_indent_four_spaces() {
+    let input = r#"{"version":"1.0.0","name":"example"}"#;
+    let result =
+        sort_package_json_with_options(input, &SortOptions::new().with_indent("    ")).unwrap();
+    assert_eq!(
+        result,
+        "{\n    \"name\": \"example\",\n    \"version\": \"1.0.0\"\n}\n"
+    );
+}
+
+#[test]
+fn test_custom_indent_nested() {
+    let input = r#"{"dependencies":{"b":"2","a":"1"},"name":"pkg"}"#;
+    let result =
+        sort_package_json_with_options(input, &SortOptions::new().with_indent("\t")).unwrap();
+    assert_eq!(
+        result,
+        "{\n\t\"name\": \"pkg\",\n\t\"dependencies\": {\n\t\t\"a\": \"1\",\n\t\t\"b\": \"2\"\n\t}\n}\n"
+    );
+}
+
+#[test]
+fn test_custom_indent_default_unchanged() {
+    let input = r#"{"version":"1.0.0","name":"example"}"#;
+    let with_default = sort_package_json_with_options(input, &SortOptions::new()).unwrap();
+    let with_explicit =
+        sort_package_json_with_options(input, &SortOptions::new().with_indent("  ")).unwrap();
+    assert_eq!(with_default, with_explicit);
+}
+
+#[test]
+fn test_custom_indent_ignored_when_not_pretty() {
+    let input = r#"{"version":"1.0.0","name":"example"}"#;
+    let result = sort_package_json_with_options(
+        input,
+        &SortOptions::new().with_pretty(false).with_indent("\t"),
+    )
+    .unwrap();
+    assert_eq!(result, r#"{"name":"example","version":"1.0.0"}"#);
+}


### PR DESCRIPTION
## Summary

Add an `indent` field to `SortOptions` that controls the indentation string used when pretty-printing. Defaults to two spaces (preserving existing behavior).

## Motivation

Downstream consumers (e.g. dprint plugins) need to respect user-configured indentation (tabs, 4 spaces, etc.) rather than being locked to 2-space indentation. Currently there is no way to customize this without bypassing `sort_package_json_with_options` entirely.

## Changes

- **`SortOptions::indent`**: New `String` field, defaults to `"  "` (two spaces).
- **`SortOptions::with_indent()`**: Builder method accepting any `Into<String>`.
- **Serialization**: Replaced `serde_json::to_writer_pretty` with `serde_json::ser::Serializer::with_formatter(PrettyFormatter::with_indent(...))` to use the custom indent string.
- **Tests**: 5 new integration tests covering tab indent, 4-space indent, nested objects, default equivalence, and compact-mode bypass.

## Breaking changes

- `SortOptions` loses `Copy` (now contains a `String`). It was already `#[non_exhaustive]` and `Clone`.
- `new()`, `with_pretty()`, `with_sort_scripts()` are no longer `const fn` (allocation in `new()` prevents it).

All existing tests pass. No changes to sorting logic.